### PR TITLE
Fix authenticaiton header for Basic auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ ClustoClient.prototype._tryRequest = function tryRequest(callback, uri, method, 
 
     var headers = {};
     if (this._auth) {
-        headers.Authorization = 'Basic: ' + this._auth;
+        headers.Authorization = 'Basic ' + this._auth;
     }
 
     self._prober.probe(boundRequest, function onBypass(err) {


### PR DESCRIPTION
As you can see at the Wikipedia site https://en.wikipedia.org/wiki/Basic_access_authentication there should not be a colon after Basic.  I'm not quite certain how this worked for you previously, but it isn't working against nginx.
